### PR TITLE
[JP-007][JP-011] feat: automate building & installing

### DIFF
--- a/.docker/rails_api/entrypoint.sh
+++ b/.docker/rails_api/entrypoint.sh
@@ -4,5 +4,7 @@ set -e
 # Remove a potentially pre-existing server.pid for Rails.
 rm -f /rails_api/tmp/pids/server.pid
 
+rails db:prepare
+
 # Then exec the container's main process (what's set as CMD in the Dockerfile).
 exec "$@"

--- a/build
+++ b/build
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Remove postgres volume to eliminate permissions
+# issue where docker will create a new volume upon
+# building which the user will not have access to
 sudo rm -rf .docker/volumes/postgres
 
 docker-compose up --build

--- a/build
+++ b/build
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+sudo rm -rf .docker/volumes/postgres
+
+docker-compose up --build

--- a/install
+++ b/install
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Generate environment variables
+cp .env.example .env
+
+# Set up front end
+cd react_ui
+asdf local nodejs 18.15.0
+npm install --global yarn
+yarn install
+
+# Set up back end
+cd ../rails_api
+asdf local ruby 3.2.0
+gem install bundler
+bundle install
+
+# Build docker containers/volumes
+cd ..
+./build

--- a/setup
+++ b/setup
@@ -5,12 +5,14 @@ cp .env.example .env
 
 # Set up front end
 cd react_ui
+asdf install nodejs 18.15.0
 asdf local nodejs 18.15.0
 npm install --global yarn
 yarn install
 
 # Set up back end
 cd ../rails_api
+asdf install ruby 3.2.0
 asdf local ruby 3.2.0
 gem install bundler
 bundle install


### PR DESCRIPTION
<!-- Use the following to name the pull request: []() Short description -->

### Resolves [JP-007](https://github.com/users/Japenner/projects/1/views/1?pane=issue&itemId=26072066) & [JP-011](https://github.com/users/Japenner/projects/1/views/1?pane=issue&itemId=26072173)

In an effort to simplify the build and installation processes, I've created a couple of bash scripts which automate the process of both. In so doing, I've also managed to track down the cause of a bug where the pg volume was being generated with the wrong permissions, leading to a bug where rebuilding containers would fail.

### Proposed changes

- Update the entrypoint.sh script to create/migrate/seed the PG database
- Create a `build` executable script to simplify the build process
- Create a `setup` executable script to automate initial setup of the application

### Security implications

None

### Reproduction steps

N/A

### Requested feedback

N/A